### PR TITLE
Update default runtime to node16

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -27,7 +27,7 @@ outputs:
   result:
     description: 'The return value of called API, stringified with `JSON.stringify`'
 runs:
-  using: 'node12'
+  using: 'node16'
   main: 'dist/index.js'
 branding:
   icon: 'activity'


### PR DESCRIPTION
Update the default runtime to [node16](https://github.blog/changelog/2021-12-10-github-actions-github-hosted-runners-now-run-node-js-16-by-default/), rather then node12. 

https://docs.github.com/en/actions/creating-actions/metadata-syntax-for-github-actions#runsusing